### PR TITLE
AutoGenerateMenuItems default value as False

### DIFF
--- a/Editor/Core/Data/Preferences.cs
+++ b/Editor/Core/Data/Preferences.cs
@@ -53,7 +53,7 @@ namespace Wireframe
         
         public static bool AutoGenerateMenuItems
         {
-            get => EditorPrefs.GetBool("BuildUploader_AutoGenerateMenuItems", true);
+            get => EditorPrefs.GetBool("BuildUploader_AutoGenerateMenuItems", false);
             set => EditorPrefs.SetBool("BuildUploader_AutoGenerateMenuItems", value);
         }
         


### PR DESCRIPTION
BuildUploader_AutoGenerateMenuItems generates the file in an immutable package folder if the package installed via package manger from GIT and its cause an error